### PR TITLE
LOG_XXX functions should be marked extern

### DIFF
--- a/src/Logger.h
+++ b/src/Logger.h
@@ -5,6 +5,9 @@
 
 #include <stdio.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
 *	plain log output
 */
@@ -24,6 +27,10 @@ void LOG_ERROR(const char* format, ...);
 void LOG_DOWNLOAD(const char* filename);
 
 void LOG_PROGRESS(long done, long total);
+
+#ifdef __cplusplus
+}
+#endif
 
 #ifdef DEBUG
 #define LOG_DEBUG(fmt, ...) \


### PR DESCRIPTION
and needed to be in order for SL to cross compile with pr-downloader as submodule. Otherwise link errors ensued.
