### PR TITLE
fix cross-compile

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,7 +37,7 @@ add_executable(${PRDOWNLOADER}
 	main.cpp
 )
 
-target_link_libraries(${PRDOWNLOADER}
+set(PRDOWNLOADER_LIBS
 	${WIN32LIBS}
 	Rapid
 	Http
@@ -45,6 +45,10 @@ target_link_libraries(${PRDOWNLOADER}
 	Widget
 	FileSystem
 )
+
+target_link_libraries( ${PRDOWNLOADER_SHARED} ${PRDOWNLOADER_LIBS} )
+target_link_libraries( ${PRDOWNLOADER_STATIC} ${PRDOWNLOADER_LIBS} )
+target_link_libraries( ${PRDOWNLOADER} ${PRDOWNLOADER_SHARED} )
 
 FILE( GLOB_RECURSE header "*.h" )
 


### PR DESCRIPTION
- link generated sub libraries into both _static and _shared pr-downloader libs
- link _shared into executable
