### PR TITLE
fix unused args warnings in soap

### DIFF
--- a/src/lib/soap/soapC.cpp
+++ b/src/lib/soap/soapC.cpp
@@ -1001,7 +1001,7 @@ SOAP_FMAC1 std::string * SOAP_FMAC2 soap_instantiate_std__string(struct soap *so
 	return (std::string*)cp->ptr;
 }
 
-SOAP_FMAC3 void SOAP_FMAC4 soap_copy_std__string(struct soap *soap, int st, int tt, void *p, size_t len, const void *q, size_t n)
+SOAP_FMAC3 void SOAP_FMAC4 soap_copy_std__string(struct soap *soap, int st, int /*tt*/, void *p, size_t len, const void *q, size_t n)
 {
 	(void)soap; (void)st; (void)len; (void)n; /* appease -Wall -Werror */
 	DBGLOG(TEST, SOAP_MESSAGE(fdebug, "Copying std::string %p -> %p\n", q, p));
@@ -1189,7 +1189,7 @@ SOAP_FMAC1 _Plasma__DownloadFileResponse * SOAP_FMAC2 soap_instantiate__Plasma__
 	return (_Plasma__DownloadFileResponse*)cp->ptr;
 }
 
-SOAP_FMAC3 void SOAP_FMAC4 soap_copy__Plasma__DownloadFileResponse(struct soap *soap, int st, int tt, void *p, size_t len, const void *q, size_t n)
+SOAP_FMAC3 void SOAP_FMAC4 soap_copy__Plasma__DownloadFileResponse(struct soap *soap, int st, int /*tt*/, void *p, size_t len, const void *q, size_t n)
 {
 	(void)soap; (void)st; (void)len; (void)n; /* appease -Wall -Werror */
 	DBGLOG(TEST, SOAP_MESSAGE(fdebug, "Copying _Plasma__DownloadFileResponse %p -> %p\n", q, p));
@@ -1323,7 +1323,7 @@ SOAP_FMAC1 _Plasma__DownloadFile * SOAP_FMAC2 soap_instantiate__Plasma__Download
 	return (_Plasma__DownloadFile*)cp->ptr;
 }
 
-SOAP_FMAC3 void SOAP_FMAC4 soap_copy__Plasma__DownloadFile(struct soap *soap, int st, int tt, void *p, size_t len, const void *q, size_t n)
+SOAP_FMAC3 void SOAP_FMAC4 soap_copy__Plasma__DownloadFile(struct soap *soap, int st, int /*tt*/, void *p, size_t len, const void *q, size_t n)
 {
 	(void)soap; (void)st; (void)len; (void)n; /* appease -Wall -Werror */
 	DBGLOG(TEST, SOAP_MESSAGE(fdebug, "Copying _Plasma__DownloadFile %p -> %p\n", q, p));
@@ -1454,7 +1454,7 @@ SOAP_FMAC1 Plasma__ArrayOfString * SOAP_FMAC2 soap_instantiate_Plasma__ArrayOfSt
 	return (Plasma__ArrayOfString*)cp->ptr;
 }
 
-SOAP_FMAC3 void SOAP_FMAC4 soap_copy_Plasma__ArrayOfString(struct soap *soap, int st, int tt, void *p, size_t len, const void *q, size_t n)
+SOAP_FMAC3 void SOAP_FMAC4 soap_copy_Plasma__ArrayOfString(struct soap *soap, int st, int /*tt*/, void *p, size_t len, const void *q, size_t n)
 {
 	(void)soap; (void)st; (void)len; (void)n; /* appease -Wall -Werror */
 	DBGLOG(TEST, SOAP_MESSAGE(fdebug, "Copying Plasma__ArrayOfString %p -> %p\n", q, p));
@@ -1591,7 +1591,7 @@ SOAP_FMAC1 xsd__base64Binary * SOAP_FMAC2 soap_instantiate_xsd__base64Binary(str
 	return (xsd__base64Binary*)cp->ptr;
 }
 
-SOAP_FMAC3 void SOAP_FMAC4 soap_copy_xsd__base64Binary(struct soap *soap, int st, int tt, void *p, size_t len, const void *q, size_t n)
+SOAP_FMAC3 void SOAP_FMAC4 soap_copy_xsd__base64Binary(struct soap *soap, int st, int /*tt*/, void *p, size_t len, const void *q, size_t n)
 {
 	(void)soap; (void)st; (void)len; (void)n; /* appease -Wall -Werror */
 	DBGLOG(TEST, SOAP_MESSAGE(fdebug, "Copying xsd__base64Binary %p -> %p\n", q, p));
@@ -1779,7 +1779,7 @@ SOAP_FMAC1 struct SOAP_ENV__Fault * SOAP_FMAC2 soap_instantiate_SOAP_ENV__Fault(
 	return (struct SOAP_ENV__Fault*)cp->ptr;
 }
 
-SOAP_FMAC3 void SOAP_FMAC4 soap_copy_SOAP_ENV__Fault(struct soap *soap, int st, int tt, void *p, size_t len, const void *q, size_t n)
+SOAP_FMAC3 void SOAP_FMAC4 soap_copy_SOAP_ENV__Fault(struct soap *soap, int st, int /*tt*/, void *p, size_t len, const void *q, size_t n)
 {
 	(void)soap; (void)st; (void)len; (void)n; /* appease -Wall -Werror */
 	DBGLOG(TEST, SOAP_MESSAGE(fdebug, "Copying struct SOAP_ENV__Fault %p -> %p\n", q, p));
@@ -1890,7 +1890,7 @@ SOAP_FMAC1 struct SOAP_ENV__Reason * SOAP_FMAC2 soap_instantiate_SOAP_ENV__Reaso
 	return (struct SOAP_ENV__Reason*)cp->ptr;
 }
 
-SOAP_FMAC3 void SOAP_FMAC4 soap_copy_SOAP_ENV__Reason(struct soap *soap, int st, int tt, void *p, size_t len, const void *q, size_t n)
+SOAP_FMAC3 void SOAP_FMAC4 soap_copy_SOAP_ENV__Reason(struct soap *soap, int st, int /*tt*/, void *p, size_t len, const void *q, size_t n)
 {
 	(void)soap; (void)st; (void)len; (void)n; /* appease -Wall -Werror */
 	DBGLOG(TEST, SOAP_MESSAGE(fdebug, "Copying struct SOAP_ENV__Reason %p -> %p\n", q, p));
@@ -2008,7 +2008,7 @@ SOAP_FMAC1 struct SOAP_ENV__Detail * SOAP_FMAC2 soap_instantiate_SOAP_ENV__Detai
 	return (struct SOAP_ENV__Detail*)cp->ptr;
 }
 
-SOAP_FMAC3 void SOAP_FMAC4 soap_copy_SOAP_ENV__Detail(struct soap *soap, int st, int tt, void *p, size_t len, const void *q, size_t n)
+SOAP_FMAC3 void SOAP_FMAC4 soap_copy_SOAP_ENV__Detail(struct soap *soap, int st, int /*tt*/, void *p, size_t len, const void *q, size_t n)
 {
 	(void)soap; (void)st; (void)len; (void)n; /* appease -Wall -Werror */
 	DBGLOG(TEST, SOAP_MESSAGE(fdebug, "Copying struct SOAP_ENV__Detail %p -> %p\n", q, p));
@@ -2128,7 +2128,7 @@ SOAP_FMAC1 struct SOAP_ENV__Code * SOAP_FMAC2 soap_instantiate_SOAP_ENV__Code(st
 	return (struct SOAP_ENV__Code*)cp->ptr;
 }
 
-SOAP_FMAC3 void SOAP_FMAC4 soap_copy_SOAP_ENV__Code(struct soap *soap, int st, int tt, void *p, size_t len, const void *q, size_t n)
+SOAP_FMAC3 void SOAP_FMAC4 soap_copy_SOAP_ENV__Code(struct soap *soap, int st, int /*tt*/, void *p, size_t len, const void *q, size_t n)
 {
 	(void)soap; (void)st; (void)len; (void)n; /* appease -Wall -Werror */
 	DBGLOG(TEST, SOAP_MESSAGE(fdebug, "Copying struct SOAP_ENV__Code %p -> %p\n", q, p));
@@ -2227,7 +2227,7 @@ SOAP_FMAC1 struct SOAP_ENV__Header * SOAP_FMAC2 soap_instantiate_SOAP_ENV__Heade
 	return (struct SOAP_ENV__Header*)cp->ptr;
 }
 
-SOAP_FMAC3 void SOAP_FMAC4 soap_copy_SOAP_ENV__Header(struct soap *soap, int st, int tt, void *p, size_t len, const void *q, size_t n)
+SOAP_FMAC3 void SOAP_FMAC4 soap_copy_SOAP_ENV__Header(struct soap *soap, int st, int /*tt*/, void *p, size_t len, const void *q, size_t n)
 {
 	(void)soap; (void)st; (void)len; (void)n; /* appease -Wall -Werror */
 	DBGLOG(TEST, SOAP_MESSAGE(fdebug, "Copying struct SOAP_ENV__Header %p -> %p\n", q, p));
@@ -2248,14 +2248,14 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_serialize___Plasma__DownloadFile(struct soap *so
 	soap_serialize_PointerTo_Plasma__DownloadFile(soap, &a->Plasma__DownloadFile);
 }
 
-SOAP_FMAC3 int SOAP_FMAC4 soap_out___Plasma__DownloadFile(struct soap *soap, const char *tag, int id, const struct __Plasma__DownloadFile *a, const char *type)
+SOAP_FMAC3 int SOAP_FMAC4 soap_out___Plasma__DownloadFile(struct soap *soap, const char */*tag*/, int /*id*/, const struct __Plasma__DownloadFile *a, const char */*type*/)
 {
 	if (soap_out_PointerTo_Plasma__DownloadFile(soap, "Plasma:DownloadFile", -1, &a->Plasma__DownloadFile, ""))
 		return soap->error;
 	return SOAP_OK;
 }
 
-SOAP_FMAC3 struct __Plasma__DownloadFile * SOAP_FMAC4 soap_in___Plasma__DownloadFile(struct soap *soap, const char *tag, struct __Plasma__DownloadFile *a, const char *type)
+SOAP_FMAC3 struct __Plasma__DownloadFile * SOAP_FMAC4 soap_in___Plasma__DownloadFile(struct soap *soap, const char */*tag*/, struct __Plasma__DownloadFile *a, const char */*type*/)
 {
 	size_t soap_flag_Plasma__DownloadFile = 1;
 	short soap_flag;
@@ -2324,7 +2324,7 @@ SOAP_FMAC1 struct __Plasma__DownloadFile * SOAP_FMAC2 soap_instantiate___Plasma_
 	return (struct __Plasma__DownloadFile*)cp->ptr;
 }
 
-SOAP_FMAC3 void SOAP_FMAC4 soap_copy___Plasma__DownloadFile(struct soap *soap, int st, int tt, void *p, size_t len, const void *q, size_t n)
+SOAP_FMAC3 void SOAP_FMAC4 soap_copy___Plasma__DownloadFile(struct soap *soap, int st, int /*tt*/, void *p, size_t len, const void *q, size_t n)
 {
 	(void)soap; (void)st; (void)len; (void)n; /* appease -Wall -Werror */
 	DBGLOG(TEST, SOAP_MESSAGE(fdebug, "Copying struct __Plasma__DownloadFile %p -> %p\n", q, p));
@@ -2510,7 +2510,7 @@ SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTo_Plasma__DownloadFileResponse(struct
 	return (*a)->soap_out(soap, tag, id, type);
 }
 
-SOAP_FMAC3 _Plasma__DownloadFileResponse ** SOAP_FMAC4 soap_in_PointerTo_Plasma__DownloadFileResponse(struct soap *soap, const char *tag, _Plasma__DownloadFileResponse **a, const char *type)
+SOAP_FMAC3 _Plasma__DownloadFileResponse ** SOAP_FMAC4 soap_in_PointerTo_Plasma__DownloadFileResponse(struct soap *soap, const char *tag, _Plasma__DownloadFileResponse **a, const char */*type*/)
 {
 	if (soap_element_begin_in(soap, tag, 1, NULL))
 		return NULL;
@@ -2565,7 +2565,7 @@ SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerTo_Plasma__DownloadFile(struct soap *s
 	return (*a)->soap_out(soap, tag, id, type);
 }
 
-SOAP_FMAC3 _Plasma__DownloadFile ** SOAP_FMAC4 soap_in_PointerTo_Plasma__DownloadFile(struct soap *soap, const char *tag, _Plasma__DownloadFile **a, const char *type)
+SOAP_FMAC3 _Plasma__DownloadFile ** SOAP_FMAC4 soap_in_PointerTo_Plasma__DownloadFile(struct soap *soap, const char *tag, _Plasma__DownloadFile **a, const char */*type*/)
 {
 	if (soap_element_begin_in(soap, tag, 1, NULL))
 		return NULL;
@@ -2620,7 +2620,7 @@ SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerToxsd__base64Binary(struct soap *soap,
 	return (*a)->soap_out(soap, tag, id, type);
 }
 
-SOAP_FMAC3 xsd__base64Binary ** SOAP_FMAC4 soap_in_PointerToxsd__base64Binary(struct soap *soap, const char *tag, xsd__base64Binary **a, const char *type)
+SOAP_FMAC3 xsd__base64Binary ** SOAP_FMAC4 soap_in_PointerToxsd__base64Binary(struct soap *soap, const char *tag, xsd__base64Binary **a, const char */*type*/)
 {
 	if (soap_element_begin_in(soap, tag, 1, NULL))
 		return NULL;
@@ -2675,7 +2675,7 @@ SOAP_FMAC3 int SOAP_FMAC4 soap_out_PointerToPlasma__ArrayOfString(struct soap *s
 	return (*a)->soap_out(soap, tag, id, type);
 }
 
-SOAP_FMAC3 Plasma__ArrayOfString ** SOAP_FMAC4 soap_in_PointerToPlasma__ArrayOfString(struct soap *soap, const char *tag, Plasma__ArrayOfString **a, const char *type)
+SOAP_FMAC3 Plasma__ArrayOfString ** SOAP_FMAC4 soap_in_PointerToPlasma__ArrayOfString(struct soap *soap, const char *tag, Plasma__ArrayOfString **a, const char */*type*/)
 {
 	if (soap_element_begin_in(soap, tag, 1, NULL))
 		return NULL;
@@ -2886,7 +2886,7 @@ SOAP_FMAC3 char ** SOAP_FMAC4 soap_get_string(struct soap *soap, char **p, const
 	return p;
 }
 
-SOAP_FMAC3 void SOAP_FMAC4 soap_default_std__vectorTemplateOfstd__string(struct soap *soap, std::vector<std::string >*p)
+SOAP_FMAC3 void SOAP_FMAC4 soap_default_std__vectorTemplateOfstd__string(struct soap */*soap*/, std::vector<std::string >*p)
 {
 	p->clear();
 }
@@ -2897,7 +2897,7 @@ SOAP_FMAC3 void SOAP_FMAC4 soap_serialize_std__vectorTemplateOfstd__string(struc
 		soap_serialize_std__string(soap, &(*i));
 }
 
-SOAP_FMAC3 int SOAP_FMAC4 soap_out_std__vectorTemplateOfstd__string(struct soap *soap, const char *tag, int id, const std::vector<std::string >*a, const char *type)
+SOAP_FMAC3 int SOAP_FMAC4 soap_out_std__vectorTemplateOfstd__string(struct soap *soap, const char *tag, int id, const std::vector<std::string >*a, const char */*type*/)
 {
 	for (std::vector<std::string >::const_iterator i = a->begin(); i != a->end(); ++i)
 	{
@@ -2967,7 +2967,7 @@ SOAP_FMAC1 std::vector<std::string > * SOAP_FMAC2 soap_instantiate_std__vectorTe
 	return (std::vector<std::string >*)cp->ptr;
 }
 
-SOAP_FMAC3 void SOAP_FMAC4 soap_copy_std__vectorTemplateOfstd__string(struct soap *soap, int st, int tt, void *p, size_t len, const void *q, size_t n)
+SOAP_FMAC3 void SOAP_FMAC4 soap_copy_std__vectorTemplateOfstd__string(struct soap *soap, int st, int /*tt*/, void *p, size_t len, const void *q, size_t n)
 {
 	(void)soap; (void)st; (void)len; (void)n; /* appease -Wall -Werror */
 	DBGLOG(TEST, SOAP_MESSAGE(fdebug, "Copying std::vector<std::string > %p -> %p\n", q, p));

--- a/src/lib/soap/stdsoap2.cpp
+++ b/src/lib/soap/stdsoap2.cpp
@@ -1895,7 +1895,7 @@ soap_putbase64(struct soap *soap, const unsigned char *s, int n)
 SOAP_FMAC1
 unsigned char*
 SOAP_FMAC2
-soap_getbase64(struct soap *soap, int *n, int malloc_flag)
+soap_getbase64(struct soap *soap, int *n, int /*malloc_flag*/)
 {
 #ifdef WITH_DOM
   if ((soap->mode & SOAP_XML_DOM) && soap->dom)
@@ -4420,7 +4420,7 @@ tcp_select(struct soap *soap, SOAP_SOCKET s, int flags, int timeout)
 #ifndef WITH_NOIO
 #ifndef PALM_1
 static SOAP_SOCKET
-tcp_accept(struct soap *soap, SOAP_SOCKET s, struct sockaddr *a, int *n)
+tcp_accept(struct soap */*soap*/, SOAP_SOCKET s, struct sockaddr *a, int *n)
 { SOAP_SOCKET fd;
   fd = accept(s, a, (SOAP_SOCKLEN_T*)n); /* portability note: see SOAP_SOCKLEN_T definition in stdsoap2.h */
 #ifdef SOCKET_CLOSE_ON_EXEC
@@ -4533,7 +4533,7 @@ tcp_disconnect(struct soap *soap)
 #ifndef WITH_NOIO
 #ifndef PALM_1
 static int
-tcp_closesocket(struct soap *soap, SOAP_SOCKET fd)
+tcp_closesocket(struct soap */*soap*/, SOAP_SOCKET fd)
 { DBGLOG(TEST, SOAP_MESSAGE(fdebug, "Close socket %d\n", (int)fd));
   return soap_closesocket(fd);
 }
@@ -4544,7 +4544,7 @@ tcp_closesocket(struct soap *soap, SOAP_SOCKET fd)
 #ifndef WITH_NOIO
 #ifndef PALM_1
 static int
-tcp_shutdownsocket(struct soap *soap, SOAP_SOCKET fd, int how)
+tcp_shutdownsocket(struct soap */*soap*/, SOAP_SOCKET fd, int how)
 { DBGLOG(TEST, SOAP_MESSAGE(fdebug, "Shutdown socket %d how=%d\n", (int)fd, how));
   return shutdown(fd, how);
 }
@@ -5520,7 +5520,7 @@ soap_decode(char *buf, size_t len, const char *val, const char *sep)
 #ifndef WITH_NOHTTP
 #ifndef PALM_1
 static const char*
-http_error(struct soap *soap, int status)
+http_error(struct soap */*soap*/, int status)
 { register const char *msg = SOAP_STR_EOS;
 #ifndef WITH_LEAN
   msg = soap_code_str(h_http_error_codes, status);
@@ -5546,7 +5546,7 @@ http_put(struct soap *soap)
 #ifndef WITH_NOHTTP
 #ifndef PALM_1
 static int
-http_get(struct soap *soap)
+http_get(struct soap */*soap*/)
 { return SOAP_GET_METHOD;
 }
 #endif
@@ -5556,7 +5556,7 @@ http_get(struct soap *soap)
 #ifndef WITH_NOHTTP
 #ifndef PALM_1
 static int
-http_405(struct soap *soap)
+http_405(struct soap */*soap*/)
 { return 405;
 }
 #endif
@@ -6581,7 +6581,7 @@ soap_free_pht(struct soap *soap)
 SOAP_FMAC1
 int
 SOAP_FMAC2
-soap_embed(struct soap *soap, const void *p, const struct soap_array *a, int n, const char *tag, int type)
+soap_embed(struct soap *soap, const void *p, const struct soap_array *a, int n, const char */*tag*/, int type)
 { register int i;
   struct soap_plist *pp;
   if (soap->version == 2)
@@ -6631,7 +6631,7 @@ soap_pointer_lookup(struct soap *soap, const void *p, int type, struct soap_plis
 SOAP_FMAC1
 int
 SOAP_FMAC2
-soap_pointer_enter(struct soap *soap, const void *p, const struct soap_array *a, int n, int type, struct soap_plist **ppp)
+soap_pointer_enter(struct soap *soap, const void *p, const struct soap_array *a, int /*n*/, int type, struct soap_plist **ppp)
 { register size_t h;
   register struct soap_plist *pp;
   if (!soap->pblk || soap->pidx >= SOAP_PTRBLK)
@@ -7799,7 +7799,7 @@ soap_id_enter(struct soap *soap, const char *id, void *p, int t, size_t n, unsig
 SOAP_FMAC1
 void
 SOAP_FMAC2
-soap_fcopy(struct soap *soap, int st, int tt, void *p, size_t len, const void *q, size_t n)
+soap_fcopy(struct soap */*soap*/, int /*st*/, int /*tt*/, void *p, size_t /*len*/, const void *q, size_t n)
 { DBGLOG(TEST,SOAP_MESSAGE(fdebug, "Copying data type=%d (target type=%d) %p -> %p (%lu bytes)\n", st, tt, q, p, (unsigned long)n));
   memcpy(p, q, n);
 }
@@ -9633,7 +9633,7 @@ soap_element_result(struct soap *soap, const char *tag)
 SOAP_FMAC1
 void
 SOAP_FMAC2
-soap_check_result(struct soap *soap, const char *tag)
+soap_check_result(struct soap *soap, const char */*tag*/)
 { if (soap->version == 2 && soap->encodingStyle)
   { soap_instring(soap, ":result", NULL, NULL, 0, 2, -1, -1);
     /* just ignore content for compliance reasons, but should compare tag to element's QName value? */
@@ -12696,7 +12696,7 @@ soap_outstring(struct soap *soap, const char *tag, int id, char *const*p, const 
 SOAP_FMAC1
 char **
 SOAP_FMAC2
-soap_instring(struct soap *soap, const char *tag, char **p, const char *type, int t, int flag, long minlen, long maxlen)
+soap_instring(struct soap *soap, const char *tag, char **p, const char */*type*/, int t, int flag, long minlen, long maxlen)
 { if (soap_element_begin_in(soap, tag, 1, NULL))
   { if (!tag || *tag != '-' || soap->error != SOAP_NO_TAG)
       return NULL;
@@ -12762,7 +12762,7 @@ soap_outwstring(struct soap *soap, const char *tag, int id, wchar_t *const*p, co
 SOAP_FMAC1
 wchar_t **
 SOAP_FMAC2
-soap_inwstring(struct soap *soap, const char *tag, wchar_t **p, const char *type, int t, long minlen, long maxlen)
+soap_inwstring(struct soap *soap, const char *tag, wchar_t **p, const char */*type*/, int t, long minlen, long maxlen)
 { if (soap_element_begin_in(soap, tag, 1, NULL))
   { if (!tag || *tag != '-' || soap->error != SOAP_NO_TAG)
       return NULL;


### PR DESCRIPTION
there are ~11 warnings of this type left (when compiled with clang)
src/lib/soap/soapC.cpp:992:38: warning: when type is in parentheses, array cannot have dynamic size
 { cp->ptr = (void*)new (std::string[n]);
