### PR TITLE
Include stdlib.h for malloc

### DIFF
--- a/src/Downloader/Http/HttpDownloader.cpp
+++ b/src/Downloader/Http/HttpDownloader.cpp
@@ -21,14 +21,7 @@
 #include <curl/curl.h>
 #include <string>
 #include <sstream>
-
-
-#ifdef __APPLE__
-#include <malloc/malloc.h>
-#else
-#include <malloc.h>
-#endif
-
+#include <stdlib.h>
 
 CHttpDownloader::CHttpDownloader()
 {


### PR DESCRIPTION
malloc.h is deprecated and unportable
