### PR TITLE
Include sys/types.h for u_int32_t

### DIFF
--- a/src/lib/md5/md5.h
+++ b/src/lib/md5/md5.h
@@ -43,7 +43,7 @@
 #ifdef WIN32
 typedef unsigned int UINT4;
 #else
-#include <stdlib.h> //typedef of u_int32_t
+#include <sys/types.h> //typedef of u_int32_t
 /* typedef a 32 bit type */
 typedef u_int32_t UINT4;
 #endif


### PR DESCRIPTION
This is required on FreeBSD, but should be tested on other systems, #ifdef may be required. For FreeBSD, that'd be

```
#if defined(__FreeBSD__)
...
#endif
```
