### PR TITLE
Fix engine extraction error under WIN32

### DIFF
--- a/src/FileSystem/FileSystem.cpp
+++ b/src/FileSystem/FileSystem.cpp
@@ -462,7 +462,7 @@ bool CFileSystem::extractEngine(const std::string& filename, const std::string& 
 		return true;
 	const std::string cfg = output + PATH_DELIMITER + "springsettings.cfg";
 	if (fileExists(cfg)) {
-		return removeFile(cfg);
+		removeFile(cfg);
 	}
 	return true;
 #else


### PR DESCRIPTION
This fixes engine extraction error under Windows. So looks like unicode is not a problem.