### PR TITLE
Added initial support for MCST Elbrus 2000 (e2k) CPU architecture

### DIFF
--- a/src/lib/7z/CpuArch.h
+++ b/src/lib/7z/CpuArch.h
@@ -20,7 +20,7 @@ If MY_CPU_LE_UNALIGN is not defined, we don't know about these properties of pla
 #define MY_CPU_AMD64
 #endif
 
-#if defined(MY_CPU_AMD64) || defined(_M_IA64)
+#if defined(MY_CPU_AMD64) || defined(_M_IA64) || defined(__e2k__)
 #define MY_CPU_64BIT
 #endif
 
@@ -48,7 +48,7 @@ If MY_CPU_LE_UNALIGN is not defined, we don't know about these properties of pla
 #define MY_CPU_LE_UNALIGN
 #endif
 
-#if defined(MY_CPU_X86_OR_AMD64) || defined(MY_CPU_ARM_LE)  || defined(MY_CPU_IA64_LE) || defined(__ARMEL__) || defined(__MIPSEL__) || defined(__LITTLE_ENDIAN__)
+#if defined(MY_CPU_X86_OR_AMD64) || defined(MY_CPU_ARM_LE) || defined(MY_CPU_IA64_LE) || defined(__ARMEL__) || defined(__MIPSEL__) || defined(__LITTLE_ENDIAN__) || defined(__e2k__)
 #define MY_CPU_LE
 #endif
 

--- a/src/pr-downloader.cpp
+++ b/src/pr-downloader.cpp
@@ -33,7 +33,7 @@ DownloadEnum::Category getPlatformEngineCat()
 	return DownloadEnum::CAT_ENGINE_WINDOWS;
 #elif defined(__APPLE__)
 	return DownloadEnum::CAT_ENGINE_MACOSX;
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__e2k__)
 	return DownloadEnum::CAT_ENGINE_LINUX64;
 #else
 	return DownloadEnum::CAT_ENGINE_LINUX;


### PR DESCRIPTION
- added initial support in pr-downloader
- added initial support in 7z lib

Added MCST Elbrus 2000 (e2k) CPU architecture initial support.
This is VLIW/EPIC architecture, like Intel Itanium.

About this architecture:
- https://en.wikipedia.org/wiki/Elbrus_2000