### PR TITLE
fixes for build on OpenBSD

### DIFF
--- a/src/FileSystem/File.cpp
+++ b/src/FileSystem/File.cpp
@@ -25,6 +25,10 @@
 #include <windows.h>
 #endif
 
+#ifdef __OpenBSD__
+#define lutimes utimes
+#endif
+
 CFile::~CFile()
 {
 	// TODO: write buffered data

--- a/src/lsl/lslunitsync/CMakeLists.txt
+++ b/src/lsl/lslunitsync/CMakeLists.txt
@@ -26,7 +26,7 @@ if(ADD_WXCONVERT)
 	target_compile_definitions(lsl-unitsync PRIVATE -DHAVE_WX)
 endif()
 
-if(UNIX AND NOT MINGW AND NOT APPLE)
+if(UNIX AND NOT MINGW AND NOT APPLE AND NOT OPENBSD)
 	find_library(RT_LIBRARY rt)
 endif()
 


### PR DESCRIPTION
OpenBSD doesn't have lutimes, but utimes can fill in here. We also don't have separate librt, so handle it like Apple etc.